### PR TITLE
two small fixes

### DIFF
--- a/ybacklight
+++ b/ybacklight
@@ -155,9 +155,9 @@ for (my $i = 0; $i <= $#ARGV; $i++) {
     } else {
         usage "Don't understand '$opt'";
     }
-
-
 }
+
+$action||='get';
 
 unless ($driver) {
     my @drivers = get_drivers;

--- a/ybacklight
+++ b/ybacklight
@@ -124,7 +124,7 @@ for (my $i = 0; $i <= $#ARGV; $i++) {
     my $optarg = $ARGV[$i+1]; # used optionally
     if ($opt =~ /^-d(?:isplay|river)?$/) {
         warn "Driver already defined, overriding" if $driver;
-        usage "$opt requires an argument" unless $optarg;
+        usage "$opt requires an argument" unless length $optarg;
         $i++; # consume $optarg
         if ($optarg =~ /:\d/) {
             warn "Driver '$optarg' looks like an X \$DISPLAY string, ignoring\n";
@@ -135,7 +135,7 @@ for (my $i = 0; $i <= $#ARGV; $i++) {
         usage "Only one action allowed" if $action;
         $action = $actions{$1}; # +/-/=
 
-        usage "$opt requires an argument" unless $optarg;
+        usage "$opt requires an argument" unless length $optarg;
         usage "$opt requires a numerical argument" unless $optarg =~ /^($num_re)%?$/;
         $action .= $1; # add percentage to action sign
         $i++; # consume $optarg


### PR DESCRIPTION
Allow 0 as an arg to -set (allows setting brightness to zero) and -d (in the unlikely event any drivers happen to be called this). Default to -get if no action was specified, as xbacklight does.