### PR TITLE
add udev rules

### DIFF
--- a/90-ybacklight.rules
+++ b/90-ybacklight.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chgrp video /sys/class/backlight/%k/brightness"
+ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chmod g+w /sys/class/backlight/%k/brightness"


### PR DESCRIPTION
some udev rules to use this without needing root, as long as you're in the video group.
this is how a lot of the other utils seem to solve this so its probably the way to go